### PR TITLE
Check for KeyError to work with IPython on command line

### DIFF
--- a/progressbar/progressbar.py
+++ b/progressbar/progressbar.py
@@ -41,7 +41,7 @@ import widgets
 # Test to see if we are in an IPython session.
 try:
   ipython = get_ipython().config['KernelApp']['parent_appname']
-except NameError:
+except (NameError, KeyError):
   ipython = None
 
 ipython_notebook_css = """

--- a/progressbar/progressbar.py
+++ b/progressbar/progressbar.py
@@ -41,7 +41,7 @@ import widgets
 # Test to see if we are in an IPython session.
 try:
   ipython = get_ipython().config['KernelApp']['parent_appname']
-except NameError:
+except NameError, KeyError:
   ipython = None
 
 ipython_notebook_css = """


### PR DESCRIPTION
IPython from the command line does not apparently have anything in
config['KernelApp'], so the lack of 'parent_appname' key throws a KeyError,
which we can just ignore and pretend that we don't have IPython at all.
