### PR TITLE
Bugfix and cleanup of outputs

### DIFF
--- a/progressbar/progressbar.py
+++ b/progressbar/progressbar.py
@@ -401,21 +401,22 @@ class ProgressBar(object):
         self.update(self.maxval)
         self.start_time = None
 
-        #Clean up notebook stuff, quite differently from regular
+        # Clean up notebook stuff, quite differently from regular
         if not ipython == 'ipython-notebook':
             self.fd.write('\n')
         else:
             from IPython.display import Javascript, display
-            #First delete the node that held the progress bar from the page
-            js="var element = document.getElementById('%s'); element.parentNode.removeChild(element);" % self.uuid
+            # First delete the node that held the progress bar from the page
+            js = """var element = document.getElementById('%s');
+                    element.parentNode.removeChild(element);""" % self.uuid
             display(Javascript(js))
 
-            #Then also remove its trace from the cell output (so it doesn't get
-            #stored with the notebook). This needs to be done for all widgets as
-            #well as for progressBar
+            # Then also remove its trace from the cell output (so it doesn't get
+            # stored with the notebook). This needs to be done for all widgets as
+            # well as for progressBar
             uuids = [str(self.uuid)]
-            uuids += [w.uuid for w in self.widgets if isinstance(w,widgets.Widget)]
-            display(Javascript('this.cleanProgressBar(%s)'%uuids))
+            uuids += [w.uuid for w in self.widgets if isinstance(w, widgets.Widget)]
+            display(Javascript('this.cleanProgressBar(%s)' % uuids))
 
         if self.signal_set:
             signal.signal(signal.SIGWINCH, signal.SIG_DFL)

--- a/progressbar/progressbar.py
+++ b/progressbar/progressbar.py
@@ -173,6 +173,32 @@ class ProgressBar(object):
             from IPython.display import Javascript, display
             display(Javascript('//%s\n$("head").append("<style>%s</style>")' %
                                (self.uuid,ipython_notebook_css)))
+            
+            #Also add a function that removes progressbar output from the cells
+            js = '''
+                  //%s -- used to remove this code blob in the end
+                  IPython.OutputArea.prototype.cleanProgressBar = function(uuids){
+
+                  //fitler by uuid-strings 
+                  var myfilter = function(output) { 
+                      var nuids = uuids.length;
+                      for (var i=0; i<nuids; i++){
+                          if (output.hasOwnProperty('html'))
+                            if (output.html.indexOf(uuids[i]) != -1)
+                              return false;
+                          if (output.hasOwnProperty('javascript'))
+                            if (output.javascript.indexOf(uuids[i]) != -1) 
+                              return false;
+                      }
+                    //keep all others
+                    return true;
+                  };
+
+                  //Filter the ouputs
+                  this.outputs = this.outputs.filter(myfilter);
+                 }'''%self.uuid
+            display(Javascript(js))
+
 
 
 

--- a/progressbar/progressbar.py
+++ b/progressbar/progressbar.py
@@ -174,33 +174,34 @@ class ProgressBar(object):
             display(Javascript('//%s\n$("head").append("<style>%s</style>")' %
                                (self.uuid,ipython_notebook_css)))
             
-            #Also add a function that removes progressbar output from the cells
+            # Also add a function that removes progressbar output from the cells
             js = '''
-                  //%s -- used to remove this code blob in the end
-                  IPython.OutputArea.prototype.cleanProgressBar = function(uuids){
+                  // %s -- used to remove this code blob in the end
+                  IPython.OutputArea.prototype.cleanProgressBar = function(uuids) {
+                      // filter by uuid-strings 
+                      var myfilter = function(output) { 
+                          var nuids = uuids.length;
+                          for (var i=0; i<nuids; i++) {
+                              if (output.hasOwnProperty('html')) {
+                                  if (output.html.indexOf(uuids[i]) != -1) {
+                                      return false;
+                                  }
+                              }
+                              if (output.hasOwnProperty('javascript')) {
+                                  if (output.javascript.indexOf(uuids[i]) != -1) {
+                                      return false;
+                                  }
+                              }
+                          }
+                          // keep all others
+                          return true;
+                      };
 
-                  //fitler by uuid-strings 
-                  var myfilter = function(output) { 
-                      var nuids = uuids.length;
-                      for (var i=0; i<nuids; i++){
-                          if (output.hasOwnProperty('html'))
-                            if (output.html.indexOf(uuids[i]) != -1)
-                              return false;
-                          if (output.hasOwnProperty('javascript'))
-                            if (output.javascript.indexOf(uuids[i]) != -1) 
-                              return false;
-                      }
-                    //keep all others
-                    return true;
-                  };
-
-                  //Filter the ouputs
-                  this.outputs = this.outputs.filter(myfilter);
-                 }'''%self.uuid
+                      // Filter the ouputs
+                      this.outputs = this.outputs.filter(myfilter);
+                };
+                ''' % self.uuid
             display(Javascript(js))
-
-
-
 
     def __call__(self, iterable):
         """Use a ProgressBar to iterate through an iterable."""

--- a/progressbar/progressbar.py
+++ b/progressbar/progressbar.py
@@ -124,7 +124,7 @@ class ProgressBar(object):
 
     _DEFAULT_MAXVAL = 100
     _DEFAULT_TERMSIZE = 80
-    _DEFAULT_WIDGETS = [widgets.Percentage(), ' ', widgets.Bar()]
+    _DEFAULT_WIDGETS = [widgets.Percentage, widgets.Bar]
 
     def __init__(self, maxval=None, widgets=None, term_width=None, poll=1,
                  left_justify=True, fd=sys.stdout, attr={}):
@@ -132,7 +132,7 @@ class ProgressBar(object):
 
         # Don't share a reference with any other progress bars
         if widgets is None:
-            widgets = list(self._DEFAULT_WIDGETS)
+            widgets = [widget() for widget in self._DEFAULT_WIDGETS]
 
         self.maxval = maxval
         self.widgets = widgets

--- a/progressbar/progressbar.py
+++ b/progressbar/progressbar.py
@@ -39,10 +39,12 @@ except ImportError:
 import widgets
 
 # Test to see if we are in an IPython session.
-try:
-  ipython = get_ipython().config['KernelApp']['parent_appname']
-except (NameError, KeyError):
-  ipython = None
+ipython = None
+for key in ['KernelApp','IPKernelApp']:
+  try:
+    ipython = get_ipython().config[key]['parent_appname']
+  except (NameError, KeyError):
+    pass
 
 ipython_notebook_css = """
 td.pb_widget {

--- a/progressbar/progressbar.py
+++ b/progressbar/progressbar.py
@@ -376,7 +376,11 @@ class ProgressBar(object):
         self.start_time = None
         if ipython == 'ipython-notebook':
             from IPython.display import Javascript, display
-            js = "$('div#%s').hide('slow');" % self.uuid
+            #First delete the node that held the progress bar from the page
+            js="var element = document.getElementById('%s'); element.parentNode.removeChild(element);" % self.uuid
+            display(Javascript(js))
+            #Then also remove its trace from the cell output (so it doesn't get stored)
+            js = "var cell = IPython.notebook.get_selected_cell(); cell.clear_output(false,false,true);"
             display(Javascript(js))
         if self.signal_set:
             signal.signal(signal.SIGWINCH, signal.SIG_DFL)

--- a/progressbar/progressbar.py
+++ b/progressbar/progressbar.py
@@ -171,8 +171,8 @@ class ProgressBar(object):
         # Install our CSS if we are in an IPython notebook
         if ipython == 'ipython-notebook':
             from IPython.display import Javascript, display
-            display(Javascript('$("head").append("<style>%s</style>")' %
-                               ipython_notebook_css))
+            display(Javascript('//%s\n$("head").append("<style>%s</style>")' %
+                               (self.uuid,ipython_notebook_css)))
 
 
 
@@ -380,7 +380,8 @@ class ProgressBar(object):
             js="var element = document.getElementById('%s'); element.parentNode.removeChild(element);" % self.uuid
             display(Javascript(js))
 
-            #Then also remove its trace from the cell output (so it doesn't get stored)
+            #Then also remove its trace from the cell output (so it doesn't get
+            #stored with the notebook)
             #This needs to be done for all widgets as well
             uuids = [str(self.uuid)]
             uuids += [w.uuid for w in self.widgets if isinstance(w,widgets.Widget)]
@@ -408,9 +409,6 @@ class ProgressBar(object):
               IPython.notebook.get_selected_cell().output_area.outputs = fout;
             '''%str(uuids)
             display(Javascript(js))
-            print js
-            sys.stdout.flush()
-
 
         if self.signal_set:
             signal.signal(signal.SIGWINCH, signal.SIG_DFL)

--- a/progressbar/widgets.py
+++ b/progressbar/widgets.py
@@ -328,9 +328,9 @@ class Bar(WidgetHFill):
         return """
         <div class="pb_bar" id="%s"></div>
         <script type="text/javascript">
-            $("div#%s").progressbar({value: 0});
+            $("div#%s").progressbar({value: 0, max: %d});
         </script>
-        """ % (self.uuid, self.uuid)
+        """ % (self.uuid, self.uuid,pbar.maxval)
 
 
     def update_js(self, pbar):


### PR DESCRIPTION
Dear Fergus,

thanks very much for this nice IPython notebook adaption. Unfortunately, I found two slight problems when running multiple ProgressBars in the same cell, such as this one

```
#Run serveral progressbars in the same output cell...
from progressbar import ProgressBar
from IPython.display import HTML,Javascript
import time
pBar = ProgressBar()
for i in range(0,3):
   display(HTML("<br><span style='color:#ff0000'>Try number %s</span>"%i))
   display(Javascript('console.log("Number of outputs",this.outputs.length);'))
   print "test"
  for x in pBar(range(0,100)):
    time.sleep(0.002)
```
- Only in the first ProgressBar the bar itself would be updated. In the other ProgressBars, only the Percentage would update.
- If running a lot of ProgressBars, a piece of JavaScript will stick in the Output cell for every update. This will not only bloat the notebook on save, but also show up as a useless piece of text when reloading the notebook. 

So, I've added some code that cleans up (nearly) all of the elements in the output area from the ProgressBar once its finished. 

Sebastian
